### PR TITLE
update prettier plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,16 +32,18 @@
     "@rollup/plugin-node-resolve": "^11.1",
     "@rollup/plugin-typescript": "^8.1",
     "@types/react": "^17",
+    "@typescript/sandbox": "^0.1.0",
     "concurrently": "^5.1.0",
+    "lz-string": "^1.4.4",
     "monaco-editor": "^0.21.3",
     "node-fetch": "^2.6.0",
     "rollup": "^2.38",
     "serve": "^11.3.0",
-    "typescript": "latest"
+    "typescript": "4.9.5"
   },
   "dependencies": {
-    "@types/prettier": "^2.1.6",
-    "prettier": "^2.2.1",
+    "@types/prettier": "^2.7.2",
+    "prettier": "^2.8.4",
     "tslib": "^2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node-fetch": "^2.6.0",
     "rollup": "^2.38",
     "serve": "^11.3.0",
-    "typescript": "4.9.5"
+    "typescript": "latest"
   },
   "dependencies": {
     "@types/prettier": "^2.7.2",

--- a/src/vendor/ds/createDesignSystem.d.ts
+++ b/src/vendor/ds/createDesignSystem.d.ts
@@ -1,4 +1,4 @@
-import type { Sandbox } from "../sandbox";
+import type { Sandbox } from "@typescript/sandbox";
 import type { DiagnosticRelatedInformation, Node } from "typescript";
 export declare type LocalStorageOption = {
     blurb: string;
@@ -13,7 +13,10 @@ export declare type OptionsListConfig = {
     style: "separated" | "rows";
     requireRestart?: true;
 };
+export declare type DesignSystem = ReturnType<ReturnType<typeof createDesignSystem>>;
 export declare const createDesignSystem: (sandbox: Sandbox) => (container: Element) => {
+    /** The element of the design system */
+    container: Element;
     /** Clear the sidebar */
     clear: () => void;
     /** Present code in a pre > code  */
@@ -31,6 +34,8 @@ export declare const createDesignSystem: (sandbox: Sandbox) => (container: Eleme
      * The type is quite small, so it should be very feasible for you to massage other data to fit into this function
      */
     listDiags: (model: import("monaco-editor").editor.ITextModel, diags: DiagnosticRelatedInformation[]) => HTMLUListElement;
+    /** Lets you remove the hovers from listDiags etc */
+    clearDeltaDecorators: (force?: true) => void;
     /** Shows a single option in local storage (adds an li to the container BTW) */
     localStorageOption: (setting: LocalStorageOption) => HTMLLIElement;
     /** Uses localStorageOption to create a list of options */
@@ -46,7 +51,9 @@ export declare const createDesignSystem: (sandbox: Sandbox) => (container: Eleme
         isEnabled?: ((input: HTMLInputElement) => boolean) | undefined;
     }) => HTMLFormElement;
     /** Renders an AST tree */
-    createASTTree: (node: Node) => HTMLDivElement;
+    createASTTree: (node: Node, settings?: {
+        closedByDefault?: true;
+    }) => HTMLDivElement;
     /** Creates an input button */
     button: (settings: {
         label: string;
@@ -58,4 +65,8 @@ export declare const createDesignSystem: (sandbox: Sandbox) => (container: Eleme
     createTabButton: (text: string) => HTMLButtonElement;
     /** A general "restart your browser" message  */
     declareRestartRequired: (i?: ((key: string) => string) | undefined) => void;
+    /** Create a new Design System instance and add it to the container. You'll need to cast
+     * this after usage, because otherwise the type-system circularly references itself
+     */
+    createSubDesignSystem: () => any;
 };

--- a/src/vendor/playground.d.ts
+++ b/src/vendor/playground.d.ts
@@ -1,4 +1,4 @@
-declare type Sandbox = import("./sandbox").Sandbox;
+declare type Sandbox = import("@typescript/sandbox").Sandbox;
 declare type Monaco = typeof import("monaco-editor");
 import { PluginUtils } from "./pluginUtils";
 import type React from "react";
@@ -48,6 +48,7 @@ export declare const setupPlayground: (sandbox: Sandbox, monaco: Monaco, config:
         copyForChatWithPreview: (e: React.MouseEvent<Element, MouseEvent>) => boolean;
         openInTSAST: () => void;
         openInBugWorkbench: () => void;
+        openInVSCodeDev: () => void;
         exportAsTweet: () => void;
     };
     // ui: import("./createUI").UI;
@@ -61,6 +62,7 @@ export declare const setupPlayground: (sandbox: Sandbox, monaco: Monaco, config:
         requireURL: (path: string) => string;
         react: typeof React;
         createDesignSystem: (container: Element) => {
+            container: Element;
             clear: () => void;
             code: (code: string) => HTMLElement;
             title: (title: string) => HTMLElement;
@@ -68,6 +70,7 @@ export declare const setupPlayground: (sandbox: Sandbox, monaco: Monaco, config:
             p: (subtitle: string) => HTMLElement;
             showEmptyScreen: (message: string) => HTMLDivElement;
             listDiags: (model: import("monaco-editor").editor.ITextModel, diags: import("typescript").DiagnosticRelatedInformation[]) => HTMLUListElement;
+            clearDeltaDecorators: (force?: true | undefined) => void;
             localStorageOption: (setting: import("./ds/createDesignSystem").LocalStorageOption) => HTMLLIElement;
             showOptionList: (options: import("./ds/createDesignSystem").LocalStorageOption[], style: import("./ds/createDesignSystem").OptionsListConfig) => void;
             createTextInput: (config: {
@@ -79,7 +82,9 @@ export declare const setupPlayground: (sandbox: Sandbox, monaco: Monaco, config:
                 keepValueAcrossReloads?: true | undefined;
                 isEnabled?: ((input: HTMLInputElement) => boolean) | undefined;
             }) => HTMLFormElement;
-            createASTTree: (node: import("typescript").Node) => HTMLDivElement;
+            createASTTree: (node: import("typescript").Node, settings?: {
+                closedByDefault?: true | undefined;
+            } | undefined) => HTMLDivElement;
             button: (settings: {
                 label: string;
                 onclick?: ((ev: MouseEvent) => void) | undefined;
@@ -87,6 +92,7 @@ export declare const setupPlayground: (sandbox: Sandbox, monaco: Monaco, config:
             createTabBar: () => HTMLDivElement;
             createTabButton: (text: string) => HTMLButtonElement;
             declareRestartRequired: (i?: ((key: string) => string) | undefined) => void;
+            createSubDesignSystem: () => any;
         };
         flashHTMLElement: (element: HTMLElement) => void;
         setNotifications: (pluginID: string, amount: number) => void;

--- a/src/vendor/pluginUtils.d.ts
+++ b/src/vendor/pluginUtils.d.ts
@@ -12,6 +12,7 @@ export declare const createUtils: (sb: any, react: typeof React) => {
      * element to the container you pass into the first param, and return the HTMLElement
      */
     createDesignSystem: (container: Element) => {
+        container: Element;
         clear: () => void;
         code: (code: string) => HTMLElement;
         title: (title: string) => HTMLElement;
@@ -19,6 +20,7 @@ export declare const createUtils: (sb: any, react: typeof React) => {
         p: (subtitle: string) => HTMLElement;
         showEmptyScreen: (message: string) => HTMLDivElement;
         listDiags: (model: import("monaco-editor").editor.ITextModel, diags: import("typescript").DiagnosticRelatedInformation[]) => HTMLUListElement;
+        clearDeltaDecorators: (force?: true | undefined) => void;
         localStorageOption: (setting: import("./ds/createDesignSystem").LocalStorageOption) => HTMLLIElement;
         showOptionList: (options: import("./ds/createDesignSystem").LocalStorageOption[], style: import("./ds/createDesignSystem").OptionsListConfig) => void;
         createTextInput: (config: {
@@ -30,7 +32,9 @@ export declare const createUtils: (sb: any, react: typeof React) => {
             keepValueAcrossReloads?: true | undefined;
             isEnabled?: ((input: HTMLInputElement) => boolean) | undefined;
         }) => HTMLFormElement;
-        createASTTree: (node: import("typescript").Node) => HTMLDivElement;
+        createASTTree: (node: import("typescript").Node, settings?: {
+            closedByDefault?: true | undefined;
+        } | undefined) => HTMLDivElement;
         button: (settings: {
             label: string;
             onclick?: ((ev: MouseEvent) => void) | undefined;
@@ -38,6 +42,7 @@ export declare const createUtils: (sb: any, react: typeof React) => {
         createTabBar: () => HTMLDivElement;
         createTabButton: (text: string) => HTMLButtonElement;
         declareRestartRequired: (i?: ((key: string) => string) | undefined) => void;
+        createSubDesignSystem: () => any;
     };
     /** Flashes a HTML Element */
     flashHTMLElement: (element: HTMLElement) => void;

--- a/src/vendor/sandbox.d.ts
+++ b/src/vendor/sandbox.d.ts
@@ -8,11 +8,13 @@ declare type Monaco = typeof import("monaco-editor");
  * These are settings for the playground which are the equivalent to props in React
  * any changes to it should require a new setup of the playground
  */
-export declare type PlaygroundConfig = {
+export declare type SandboxConfig = {
     /** The default source code for the playground */
     text: string;
-    /** Should it run the ts or js IDE services */
-    useJavaScript: boolean;
+    /** @deprecated */
+    useJavaScript?: boolean;
+    /** The default file for the playground  */
+    filetype: "js" | "ts" | "d.ts";
     /** Compiler options which are automatically just forwarded on */
     compilerOptions: CompilerOptions;
     /** Optional monaco settings overrides */
@@ -25,6 +27,8 @@ export declare type PlaygroundConfig = {
     suppressAutomaticallyGettingDefaultText?: true;
     /** Suppress setting compiler options from the compiler flags from query params */
     suppressAutomaticallyGettingCompilerFlags?: true;
+    /** Optional path to TypeScript worker wrapper class script, see https://github.com/microsoft/monaco-typescript/pull/65  */
+    customTypeScriptWorkerPath?: string;
     /** Logging system */
     logger: {
         log: (...args: any[]) => void;
@@ -41,8 +45,10 @@ export declare type PlaygroundConfig = {
 export declare function defaultPlaygroundSettings(): {
     /** The default source code for the playground */
     text: string;
-    /** Should it run the ts or js IDE services */
-    useJavaScript: boolean;
+    /** @deprecated */
+    useJavaScript?: boolean | undefined;
+    /** The default file for the playground  */
+    filetype: "js" | "ts" | "d.ts";
     /** Compiler options which are automatically just forwarded on */
     compilerOptions: import("monaco-editor").languages.typescript.CompilerOptions;
     /** Optional monaco settings overrides */
@@ -55,6 +61,8 @@ export declare function defaultPlaygroundSettings(): {
     suppressAutomaticallyGettingDefaultText?: true | undefined;
     /** Suppress setting compiler options from the compiler flags from query params */
     suppressAutomaticallyGettingCompilerFlags?: true | undefined;
+    /** Optional path to TypeScript worker wrapper class script, see https://github.com/microsoft/monaco-typescript/pull/65  */
+    customTypeScriptWorkerPath?: string | undefined;
     /** Logging system */
     logger: {
         log: (...args: any[]) => void;
@@ -66,17 +74,19 @@ export declare function defaultPlaygroundSettings(): {
     domID: string;
 };
 /** Creates a sandbox editor, and returns a set of useful functions and the editor */
-export declare const createTypeScriptSandbox: (partialConfig: Partial<PlaygroundConfig>, monaco: Monaco, ts: typeof import("typescript")) => {
+export declare const createTypeScriptSandbox: (partialConfig: Partial<SandboxConfig>, monaco: Monaco, ts: typeof import("typescript")) => {
     /** The same config you passed in */
     config: {
         text: string;
-        useJavaScript: boolean;
+        useJavaScript?: boolean | undefined;
+        filetype: "js" | "ts" | "d.ts";
         compilerOptions: CompilerOptions;
         monacoSettings?: import("monaco-editor").editor.IEditorOptions | undefined;
         acquireTypes: boolean;
         supportTwoslashCompilerOptions: boolean;
         suppressAutomaticallyGettingDefaultText?: true | undefined;
         suppressAutomaticallyGettingCompilerFlags?: true | undefined;
+        customTypeScriptWorkerPath?: string | undefined;
         logger: {
             log: (...args: any[]) => void;
             error: (...args: any[]) => void;
@@ -86,7 +96,7 @@ export declare const createTypeScriptSandbox: (partialConfig: Partial<Playground
         domID: string;
     };
     /** A list of TypeScript versions you can use with the TypeScript sandbox */
-    supportedVersions: readonly ["4.2.0-beta", "4.1.3", "4.0.5", "3.9.7", "3.8.3", "3.7.5", "3.6.3", "3.5.1", "3.3.3", "3.1.6", "3.0.1", "2.8.1", "2.7.2", "2.4.1"];
+    supportedVersions: readonly ["4.9.5", "4.8.4", "4.7.4", "4.6.4", "4.5.5", "4.4.4", "4.3.5", "4.2.3", "4.1.5", "4.0.5", "3.9.7", "3.8.3", "3.7.5", "3.6.3", "3.5.1", "3.3.3", "3.1.6", "3.0.1", "2.8.1", "2.7.2", "2.4.1"];
     /** The monaco editor instance */
     editor: import("monaco-editor").editor.IStandaloneCodeEditor;
     /** Either "typescript" or "javascript" depending on your config */
@@ -123,10 +133,12 @@ export declare const createTypeScriptSandbox: (partialConfig: Partial<Playground
      *
      * Try to use this sparingly as it can be computationally expensive, at the minimum you should be using the debounced setup.
      *
+     * Accepts an optional fsMap which you can use to add any files, or overwrite the default file.
+     *
      * TODO: It would be good to create an easy way to have a single program instance which is updated for you
      * when the monaco model changes.
      */
-    setupTSVFS: () => Promise<{
+    setupTSVFS: (fsMapAdditions?: Map<string, string>) => Promise<{
         program: import("typescript").Program;
         system: import("typescript").System;
         host: {
@@ -139,7 +151,7 @@ export declare const createTypeScriptSandbox: (partialConfig: Partial<Playground
     createTSProgram: () => Promise<import("typescript").Program>;
     /** The Sandbox's default compiler options  */
     compilerDefaults: {
-        [x: string]: string | number | boolean | string[] | (string | number)[] | import("monaco-editor").languages.typescript.MapLike<string[]> | null | undefined;
+        [x: string]: import("monaco-editor").languages.typescript.CompilerOptionsValue;
         allowJs?: boolean | undefined;
         allowSyntheticDefaultImports?: boolean | undefined;
         allowUmdGlobalAccess?: boolean | undefined;
@@ -233,13 +245,21 @@ export declare const createTypeScriptSandbox: (partialConfig: Partial<Playground
     /** A copy of lzstring, which is used to archive/unarchive code */
     // lzstring: typeof lzstring;
     /** Returns compiler options found in the params of the current page */
-    createURLQueryWithCompilerOptions: (sandbox: any, paramOverrides?: any) => string;
-    /** Returns compiler options in the source code using twoslash notation */
+    createURLQueryWithCompilerOptions: (_sandbox: any, paramOverrides?: any) => string;
+    /**
+     * @deprecated Use `getTwoSlashCompilerOptions` instead.
+     *
+     * Returns compiler options in the source code using twoslash notation
+     */
     getTwoSlashComplierOptions: (code: string) => any;
+    /** Returns compiler options in the source code using twoslash notation */
+    getTwoSlashCompilerOptions: (code: string) => any;
     /** Gets to the current monaco-language, this is how you talk to the background webworkers */
     languageServiceDefaults: import("monaco-editor").languages.typescript.LanguageServiceDefaults;
     /** The path which represents the current file using the current compiler options */
     filepath: string;
+    /** Adds a file to the vfs used by the editor */
+    addLibraryToRuntime: (code: string, _path: string) => void;
 };
 export declare type Sandbox = ReturnType<typeof createTypeScriptSandbox>;
 export {};

--- a/src/vendor/tsWorker.d.ts
+++ b/src/vendor/tsWorker.d.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import ts from "typescript";
 export declare class TypeScriptWorker implements ts.LanguageServiceHost {
     private _ctx;
     private _extraLibs;
@@ -35,6 +35,8 @@ export declare class TypeScriptWorker implements ts.LanguageServiceHost {
     getEmitOutput(fileName: string): Promise<ts.EmitOutput>;
     getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[], formatOptions: ts.FormatCodeOptions): Promise<ReadonlyArray<ts.CodeFixAction>>;
     updateExtraLibs(extraLibs: IExtraLibs): void;
+    readFile(path: string, encoding?: string | undefined): string | undefined;
+    fileExists(path: string): boolean;
 }
 export interface IExtraLib {
     content: string;

--- a/src/vendor/typescript-vfs.d.ts
+++ b/src/vendor/typescript-vfs.d.ts
@@ -1,4 +1,3 @@
-
 declare type System = import("typescript").System;
 declare type CompilerOptions = import("typescript").CompilerOptions;
 declare type CustomTransformers = import("typescript").CustomTransformers;
@@ -36,7 +35,7 @@ export declare const knownLibFilesForCompilerOptions: (compilerOptions: Compiler
  * Sets up a Map with lib contents by grabbing the necessary files from
  * the local copy of typescript via the file system.
  */
-export declare const createDefaultMapFromNodeModules: (compilerOptions: CompilerOptions, ts?: typeof import("typescript") | undefined) => Map<string, string>;
+export declare const createDefaultMapFromNodeModules: (compilerOptions: CompilerOptions, ts?: typeof import("typescript"), tsLibDirectory?: string) => Map<string, string>;
 /**
  * Adds recursively files from the FS into the map based on the folder
  */
@@ -55,7 +54,7 @@ export declare const addFilesForTypesIntoFolder: (map: Map<string, string>) => v
  * @param fetcher an optional replacement for the global fetch function (tests mainly)
  * @param storer an optional replacement for the localStorage global (tests mainly)
  */
-export declare const createDefaultMapFromCDN: (options: CompilerOptions, version: string, cache: boolean, ts: TS, lzstring?: any | undefined, fetcher?: typeof fetch | undefined, storer?: Storage | undefined) => Promise<Map<string, string>>;
+export declare const createDefaultMapFromCDN: (options: CompilerOptions, version: string, cache: boolean, ts: TS, lzstring?: typeof import("lz-string"), fetcher?: typeof fetch, storer?: typeof localStorage) => Promise<Map<string, string>>;
 /**
  * Creates an in-memory System object which can be used in a TypeScript program, this
  * is what provides read/write aspects of the virtual fs
@@ -66,7 +65,7 @@ export declare function createSystem(files: Map<string, string>): System;
  * a set of virtual files which are prioritised over the FS versions, then a path to the root of your
  * project (basically the folder your node_modules lives)
  */
-export declare function createFSBackedSystem(files: Map<string, string>, _projectRoot: string, ts: TS): System;
+export declare function createFSBackedSystem(files: Map<string, string>, _projectRoot: string, ts: TS, tsLibDirectory?: string): System;
 /**
  * Creates an in-memory CompilerHost -which is essentially an extra wrapper to System
  * which works with TypeScript objects - returns both a compiler host, and a way to add new SourceFile

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,10 +61,10 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz"
   integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
 
-"@types/prettier@^2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.1.6.tgz#f4b1efa784e8db479cdb8b14403e2144b1e9ff03"
-  integrity sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
+"@types/prettier@^2.7.2":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
+  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -85,6 +85,26 @@
   integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
+
+"@typescript/ata@0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@typescript/ata/-/ata-0.9.3.tgz#3ee8f4a43d071a156f7d0a819442db64025cfce5"
+  integrity sha512-/mETZakA5iOT8j8N8/ZUPLEsvSgMJz+cWt9Le1Q9dEwRXwDzekKXw3tpgrq77gaSxgE/Mn/nvtx8uzS41CmZKQ==
+
+"@typescript/sandbox@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@typescript/sandbox/-/sandbox-0.1.0.tgz#175bbaa2e994846f074635e3e8d6e865b5156394"
+  integrity sha512-f2pUCF3aNk3cdOuL0M7k8Vgzl4/P3ltgoZ5QWILqwp8Fb3SqLPKFSlTIKmn7Y8B7ojSz0tNQsZwH1syN6gAoSw==
+  dependencies:
+    "@typescript/ata" "0.9.3"
+    "@typescript/vfs" "1.3.5"
+
+"@typescript/vfs@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@typescript/vfs/-/vfs-1.3.5.tgz#801e3c97b5beca4ff5b8763299ca5fd605b862b8"
+  integrity sha512-pI8Saqjupf9MfLw7w2+og+fmb0fZS0J6vsKXXrp4/PDXEFvntgzXmChCXC/KefZZS0YGS6AT8e0hGAJcTsdJlg==
+  dependencies:
+    debug "^4.1.1"
 
 "@zeit/schemas@2.6.0":
   version "2.6.0"
@@ -316,6 +336,13 @@ debug@2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^4.1.1:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -551,6 +578,11 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -608,6 +640,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -720,10 +757,10 @@ pify@^3.0.0:
   resolved "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
-prettier@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -992,10 +1029,10 @@ tslib@^2.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-typescript@latest:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
-  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+typescript@4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 update-check@1.5.2:
   version "1.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,7 +1029,7 @@ tslib@^2.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
-typescript@4.9.5:
+typescript@latest:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
This PR updates `prettier` to the latest version to support newer TypeScript features like the [satisfies](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html) operator.