### PR TITLE
register prettier as the formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "typescript": "latest"
   },
   "dependencies": {
-    "@types/prettier": "^2.7.2",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.2",
     "tslib": "^2.1"
   }
 }

--- a/src/vendor/sandbox.d.ts
+++ b/src/vendor/sandbox.d.ts
@@ -96,7 +96,7 @@ export declare const createTypeScriptSandbox: (partialConfig: Partial<SandboxCon
         domID: string;
     };
     /** A list of TypeScript versions you can use with the TypeScript sandbox */
-    supportedVersions: readonly ["5.1.3", "5.0.4", "4.9.5", "4.8.4", "4.7.4", "4.6.4", "4.5.5", "4.4.4", "4.3.5", "4.2.3", "4.1.5", "4.0.5", "3.9.7", "3.8.3", "3.7.5", "3.6.3", "3.5.1", "3.3.3", "3.1.6", "3.0.1", "2.8.1", "2.7.2", "2.4.1"];
+    supportedVersions: readonly ["5.2.1-rc", "5.2.0-beta", "5.1.6", "5.0.4", "4.9.5", "4.8.4", "4.7.4", "4.6.4", "4.5.5", "4.4.4", "4.3.5", "4.2.3", "4.1.5", "4.0.5", "3.9.7", "3.8.3", "3.7.5", "3.6.3", "3.5.1", "3.3.3", "3.1.6", "3.0.1", "2.8.1", "2.7.2", "2.4.1"];
     /** The monaco editor instance */
     editor: import("monaco-editor").editor.IStandaloneCodeEditor;
     /** Either "typescript" or "javascript" depending on your config */

--- a/src/vendor/typescript-vfs.d.ts
+++ b/src/vendor/typescript-vfs.d.ts
@@ -25,7 +25,8 @@ export interface VirtualTypeScriptEnvironment {
 export declare function createVirtualTypeScriptEnvironment(sys: System, rootFiles: string[], ts: TS, compilerOptions?: CompilerOptions, customTransformers?: CustomTransformers): VirtualTypeScriptEnvironment;
 /**
  * Grab the list of lib files for a particular target, will return a bit more than necessary (by including
- * the dom) but that's OK
+ * the dom) but that's OK, we're really working with the constraint that you can't get a list of files
+ * when running in a browser.
  *
  * @param target The compiler settings target baseline
  * @param ts A copy of the TypeScript module
@@ -34,8 +35,11 @@ export declare const knownLibFilesForCompilerOptions: (compilerOptions: Compiler
 /**
  * Sets up a Map with lib contents by grabbing the necessary files from
  * the local copy of typescript via the file system.
+ *
+ * The first two args are un-used, but kept around so as to not cause a
+ * semver major bump for no gain to module users.
  */
-export declare const createDefaultMapFromNodeModules: (compilerOptions: CompilerOptions, ts?: typeof import("typescript"), tsLibDirectory?: string) => Map<string, string>;
+export declare const createDefaultMapFromNodeModules: (_compilerOptions: CompilerOptions, _ts?: typeof import("typescript"), tsLibDirectory?: string) => Map<string, string>;
 /**
  * Adds recursively files from the FS into the map based on the folder
  */

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,11 +61,6 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz"
   integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
 
-"@types/prettier@^2.7.2":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
-  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
-
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz"
@@ -757,10 +752,10 @@ pify@^3.0.0:
   resolved "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.2.tgz#78fcecd6d870551aa5547437cdae39d4701dca5b"
+  integrity sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==
 
 pseudomap@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This pr makes it so the plugin registers prettier as the formatter. It makes it so when you use `Alt + Shift + F` prettier is called instead of the default formatter

This allows the edit to part of the undo history which means that you can just undo the format and get back to the previous code.